### PR TITLE
feat: 주식 종목 삭제(DELETE) API 구현

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,6 +4,7 @@ from sqlalchemy.orm import Session
 from .database import engine, SessionLocal
 from . import models, schemas
 from typing import List
+from fastapi import HTTPException
 
 # 데이터베이스 테이블 생성
 models.Base.metadata.create_all(bind=engine)
@@ -18,13 +19,7 @@ def get_db():
     finally:
         db.close()
 
-# 전체 주식 목록 조회
-@app.get("/stocks", response_model=List[schemas.StockRead])
-def read_stocks(db: Session = Depends(get_db)):
-    stocks = db.query(models.Stock).all()
-    return stocks
-
-# 신규 주식 정보 저장
+# [Create] 신규 주식 정보 저장
 @app.post("/stocks")
 def create_stock(stock: schemas.StockCreate, db: Session = Depends(get_db)):
     db_stock = models.Stock(
@@ -41,6 +36,24 @@ def create_stock(stock: schemas.StockCreate, db: Session = Depends(get_db)):
 
     return{"message": "저장 완료!", "data": db_stock}
 
+# [Read] 전체 주식 목록 조회
+@app.get("/stocks", response_model=List[schemas.StockRead])
+def read_stocks(db: Session = Depends(get_db)):
+    stocks = db.query(models.Stock).all()
+    return stocks
+
+# [Delete] 주식 정보 삭제
+@app.delete("/stocks/{id}")
+def delete_stock(id: int, db: Session = Depends(get_db)):
+    db_stock = db.query(models.Stock).filter(models.Stock.id == id).first()
+
+    if not db_stock:
+        raise HTTPException(status_code=404, detail="해당 ID의 주식 정보를 찾을수 없습니다.")
+    
+    db.delete(db_stock)
+    db.commit()
+
+    return {"message": f"ID {id}번 주식 정보가 삭제되었습니다."}
 
 # 서버 테스트
 @app.get("/")


### PR DESCRIPTION
📝 PR 내용
이번 작업에서는 특정 주식 종목을 삭제할 수 있는 DELETE API를 구현하였습니다.

🛠 주요 작업 내용
엔드포인트 추가: DELETE /stocks/{id} 경로 구현

삭제 로직: DB에서 해당 ID의 데이터를 찾아 안전하게 삭제(db.delete)

예외 처리: 삭제하려는 ID가 존재하지 않을 경우 404 Not Found 에러를 반환하여 올바른 API 응답을 수행하도록 처리

🧪 테스트 확인 사항
존재하는 데이터 삭제 시 성공 메시지 반환 확인

존재하지 않는 데이터 삭제 요청 시 404 에러 발생 확인

🚀 관련 이슈
Closes #5